### PR TITLE
rename platform folder to dependencies in readme

### DIFF
--- a/core-customize/README.md
+++ b/core-customize/README.md
@@ -6,7 +6,7 @@
 >    using the correct file name, e.g.
 >
 >    ```bash
->    cp ~/Downloads/CXCOMM201100P*.ZIP ./platform/hybris-commerce-suite-2011.6.zip
+>    cp ~/Downloads/CXCOMM201100P*.ZIP ./dependencies/hybris-commerce-suite-2011.6.zip
 >    ```
 >    *Or* configure your S-User (e.g. using `gradle.properties`) and run `./gradlew downloadAndVerifyPlatform`
 >    

--- a/core-customize/README.md
+++ b/core-customize/README.md
@@ -2,7 +2,7 @@
 
 > **Initial project bootstrap**
 >
-> 1. Download the latest SAP Commerce 2011 release zip file and put it into the `platform` folder
+> 1. Download the latest SAP Commerce 2011 release zip file and put it into the `dependencies` folder
 >    using the correct file name, e.g.
 >
 >    ```bash


### PR DESCRIPTION
The folder was originially named platform but later renamed to dependencies. The README was modify to reflect that change.