### PR TITLE
include generated core and facades extensions

### DIFF
--- a/core-customize/bootstrap/config-template/localextensions.xml
+++ b/core-customize/bootstrap/config-template/localextensions.xml
@@ -9,6 +9,8 @@
     
     <extension name="@projectName@backoffice"/>
     <extension name="@projectName@initialdata"/>
+    <extension name="@projectName@core"/>
+    <extension name="@projectName@facades"/>
     <extension name="@projectName@storefront"/>
     <extension name="@projectName@fulfilmentprocess"/>
     <extension name="@projectName@occ" />


### PR DESCRIPTION
if the project doesnt make use of the storefront / run headless, the dependency declared in the projects storefront to the facades gets lost and so does the transient dependency to core. This leads to unexpected build failures that can be avoided by declaring these core extensions. I thought it might be a good idea to assist project setup by not having to deal with this edge-case misconfiguration.