### PR TITLE
make download urls and checksums configurable through gradle.properties

### DIFF
--- a/core-customize/build.gradle.kts
+++ b/core-customize/build.gradle.kts
@@ -24,8 +24,11 @@ if (project.hasProperty("sUser") && project.hasProperty("sUserPass")) {
     val SUSERPASS = project.property("sUserPass") as String
 
     val COMMERCE_VERSION = CCV2.manifest.commerceSuiteVersion
+    val commerceSuiteDownloadUrl = project.property("com.sap.softwaredownloads.commerceSuite.${COMMERCE_VERSION}.downloadUrl")
+    val commerceSuiteChecksum = project.property("com.sap.softwaredownloads.commerceSuite.${COMMERCE_VERSION}.checksum")
+    
     tasks.register<Download>("downloadPlatform") {
-        src("https://softwaredownloads.sap.com/file/0020000000989902021")
+        src(commerceSuiteDownloadUrl)
         dest(file("${DEPENDENCY_FOLDER}/hybris-commerce-suite-${COMMERCE_VERSION}.zip"))
         username(SUSER)
         password(SUSERPASS)
@@ -39,7 +42,7 @@ if (project.hasProperty("sUser") && project.hasProperty("sUserPass")) {
         dependsOn("downloadPlatform") 
         src(file("dependencies/hybris-commerce-suite-${COMMERCE_VERSION}.zip"))
         algorithm("SHA-256")
-        checksum("add4f893b349770c3f918042784b6c08ed7114ba5c98231f7de7e725b2a02803")
+        checksum(commerceSuiteChecksum)
     }
 
     tasks.named("bootstrapPlatform") {
@@ -49,8 +52,11 @@ if (project.hasProperty("sUser") && project.hasProperty("sUserPass")) {
     //check if Integration Extension Pack is configured and download it too
     if (CCV2.manifest.extensionPacks.any{"hybris-commerce-integrations".equals(it.name)}) {
         val INTEXTPACK_VERSION = CCV2.manifest.extensionPacks.first{"hybris-commerce-integrations".equals(it.name)}.version
+        val commerceIntegrationsDownloadUrl = project.property("com.sap.softwaredownloads.commerceIntegrations.${COMMERCE_VERSION}.downloadUrl")
+        val commerceIntegrationsChecksum = project.property("com.sap.softwaredownloads.commerceIntegrations.${COMMERCE_VERSION}.checksum")
+        
         tasks.register<Download>("downloadIntExtPack") {
-            src("https://softwaredownloads.sap.com/file/0020000001002692021")
+            src(commerceIntegrationsDownloadUrl)
             dest(file("${DEPENDENCY_FOLDER}/hybris-commerce-integrations-${INTEXTPACK_VERSION}.zip"))
             username(SUSER)
             password(SUSERPASS)
@@ -64,7 +70,7 @@ if (project.hasProperty("sUser") && project.hasProperty("sUserPass")) {
             dependsOn("downloadIntExtPack")
             src(file("${DEPENDENCY_FOLDER}/hybris-commerce-integrations-${INTEXTPACK_VERSION}.zip"))
             algorithm("SHA-256")
-            checksum("352fcb5b9b7b58ebc50f61873351e88ab343cbbd28955fd3332653d2284c266c")
+            checksum(commerceIntegrationsChecksum)
         }
 
         tasks.named("bootstrapPlatform") {

--- a/core-customize/gradle.properties
+++ b/core-customize/gradle.properties
@@ -1,0 +1,29 @@
+# SAP Commerce Suite 2011
+com.sap.softwaredownloads.commerceSuite.2011.14.downloadUrl=https://softwaredownloads.sap.com/file/0020000001791292021
+com.sap.softwaredownloads.commerceSuite.2011.14.checksum=8df31cd2e78b016fa983e14aca0e2b78b91e1fab02ed7cf44d5a5ac84665a2d5
+com.sap.softwaredownloads.commerceSuite.2011.15.downloadUrl=https://softwaredownloads.sap.com/file/0020000001825962021
+com.sap.softwaredownloads.commerceSuite.2011.15.checksum=fa2100113f44743e2071e33af34d64178e1733a291d66e7d5af111c00a1aa898
+
+# SAP Commerce Suite 2105
+com.sap.softwaredownloads.commerceSuite.2105.4.downloadUrl=https://softwaredownloads.sap.com/file/0020000001791262021
+com.sap.softwaredownloads.commerceSuite.2105.4.checksum=9cc16b492d56c96ee58b5be7c4ab6d67d421431da54e593baed470e751a01bfe
+com.sap.softwaredownloads.commerceSuite.2105.5.downloadUrl=https://softwaredownloads.sap.com/file/0020000001825982021
+com.sap.softwaredownloads.commerceSuite.2105.5.checksum=7cd560a42f165966873694e2e3c80779aac2902561b6034978deab33b5481a60
+
+# SAP Commerce Integrations 2005
+com.sap.softwaredownloads.commerceIntegrations.2005.4.downloadUrl=https://softwaredownloads.sap.com/file/0020000001002682021
+com.sap.softwaredownloads.commerceIntegrations.2005.4.checksum=afe8b7be15eb3d96e44f70e802a22aa34e979c78ab09a38121592ef9144ac079
+com.sap.softwaredownloads.commerceIntegrations.2005.5.downloadUrl=https://softwaredownloads.sap.com/file/0020000001165032021
+com.sap.softwaredownloads.commerceIntegrations.2005.5.checksum=b367a36084e63540e39ffbcfd7dbc037e0dd6685bfefc68e0ed60064fcca3de0
+
+# SAP Commerce Integrations 2102
+com.sap.softwaredownloads.commerceIntegrations.2102.3.downloadUrl=https://softwaredownloads.sap.com/file/0020000001395712021
+com.sap.softwaredownloads.commerceIntegrations.2102.3.checksum=1930e7177c49aec2ada3826b5db5094d90d17f85fb8535b668b2274964e3b16b
+com.sap.softwaredownloads.commerceIntegrations.2102.4.downloadUrl=https://softwaredownloads.sap.com/file/0020000001508662021
+com.sap.softwaredownloads.commerceIntegrations.2102.4.checksum=0334de7dcc0917cdded35db05623f688205a0012ef96e6bd316a28cf55bb5af6
+
+# SAP Commerce Integrations 2108
+com.sap.softwaredownloads.commerceIntegrations.2108.1.downloadUrl=https://softwaredownloads.sap.com/file/0020000001508642021
+com.sap.softwaredownloads.commerceIntegrations.2108.1.checksum=200f8c9f59bd14f9ab247af9e3efb5ecd2061ac070ab3b9019f31c7a2f20f000
+com.sap.softwaredownloads.commerceIntegrations.2108.2.downloadUrl=https://softwaredownloads.sap.com/file/0020000001645522021
+com.sap.softwaredownloads.commerceIntegrations.2108.2.checksum=be97def776bcae60ed31de91d1421da0ae8ec02eca6945467af9eabe3f6c470a


### PR DESCRIPTION
While I am still unhappy with this solution, as it requires continuous maintenance of the properties files in all projects, this is a first step in the right direction. I have also included the configuration for the last 2-3 releases with the latest 2 patch levels.

At mid-term, it would be great to have the configuration being stored globally.

Issues: #18 