### PR TITLE
Improvements to build script for local environment

### DIFF
--- a/core-customize/build.gradle.kts
+++ b/core-customize/build.gradle.kts
@@ -9,6 +9,9 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import de.undercouch.gradle.tasks.download.Download
 import de.undercouch.gradle.tasks.download.Verify
 
+import java.time.Instant
+import java.util.Base64
+
 val DEPENDENCY_FOLDER = "dependencies"
 repositories {
     flatDir { dirs(DEPENDENCY_FOLDER) }
@@ -22,6 +25,7 @@ repositories {
 if (project.hasProperty("sUser") && project.hasProperty("sUserPass")) {
     val SUSER = project.property("sUser") as String
     val SUSERPASS = project.property("sUserPass") as String
+    val AUTHORIZATION = Base64.getEncoder().encodeToString((SUSER + ":" + SUSERPASS).toByteArray())
 
     val COMMERCE_VERSION = CCV2.manifest.commerceSuiteVersion
     val commerceSuiteDownloadUrl = project.property("com.sap.softwaredownloads.commerceSuite.${COMMERCE_VERSION}.downloadUrl")
@@ -30,8 +34,7 @@ if (project.hasProperty("sUser") && project.hasProperty("sUserPass")) {
     tasks.register<Download>("downloadPlatform") {
         src(commerceSuiteDownloadUrl)
         dest(file("${DEPENDENCY_FOLDER}/hybris-commerce-suite-${COMMERCE_VERSION}.zip"))
-        username(SUSER)
-        password(SUSERPASS)
+        header("Authorization", "Basic ${AUTHORIZATION}")
         overwrite(false)
         tempAndMove(true)
         onlyIfModified(true)
@@ -40,7 +43,7 @@ if (project.hasProperty("sUser") && project.hasProperty("sUserPass")) {
 
     tasks.register<Verify>("downloadAndVerifyPlatform") {
         dependsOn("downloadPlatform") 
-        src(file("dependencies/hybris-commerce-suite-${COMMERCE_VERSION}.zip"))
+        src(file("${DEPENDENCY_FOLDER}/hybris-commerce-suite-${COMMERCE_VERSION}.zip"))
         algorithm("SHA-256")
         checksum(commerceSuiteChecksum)
     }
@@ -52,14 +55,13 @@ if (project.hasProperty("sUser") && project.hasProperty("sUserPass")) {
     //check if Integration Extension Pack is configured and download it too
     if (CCV2.manifest.extensionPacks.any{"hybris-commerce-integrations".equals(it.name)}) {
         val INTEXTPACK_VERSION = CCV2.manifest.extensionPacks.first{"hybris-commerce-integrations".equals(it.name)}.version
-        val commerceIntegrationsDownloadUrl = project.property("com.sap.softwaredownloads.commerceIntegrations.${COMMERCE_VERSION}.downloadUrl")
-        val commerceIntegrationsChecksum = project.property("com.sap.softwaredownloads.commerceIntegrations.${COMMERCE_VERSION}.checksum")
+        val commerceIntegrationsDownloadUrl = project.property("com.sap.softwaredownloads.commerceIntegrations.${INTEXTPACK_VERSION}.downloadUrl")
+        val commerceIntegrationsChecksum = project.property("com.sap.softwaredownloads.commerceIntegrations.${INTEXTPACK_VERSION}.checksum")
         
         tasks.register<Download>("downloadIntExtPack") {
             src(commerceIntegrationsDownloadUrl)
             dest(file("${DEPENDENCY_FOLDER}/hybris-commerce-integrations-${INTEXTPACK_VERSION}.zip"))
-            username(SUSER)
-            password(SUSERPASS)
+            header("Authorization", "Basic ${AUTHORIZATION}")
             overwrite(false)
             tempAndMove(true)
             onlyIfModified(true)
@@ -80,10 +82,45 @@ if (project.hasProperty("sUser") && project.hasProperty("sUserPass")) {
 }
 
 tasks.register<WriteProperties>("generateLocalProperties") {
-    comment = "GENEREATED AT " + java.time.Instant.now()
+    comment = "GENEREATED AT " + Instant.now()
     outputFile = project.file("hybris/config/local.properties")
+    property("hybris.optional.config.dir", project.file("hybris/config/local-config").absolutePath)
+    doLast {
+        mkdir(project.file("hybris/config/local-config/"))
+    }
+}
 
-    property("hybris.optional.config.dir", "\${HYBRIS_CONFIG_DIR}/local-config")
+val symlinkConfigTask = tasks.register("symlinkConfig")
+val localConfig = file("hybris/config/local-config")
+mapOf(
+    "10-local.properties" to file("hybris/config/cloud/common.properties"),
+    "20-local.properties" to file("hybris/config/cloud/persona/development.properties"),
+    "50-local.properties" to file("hybris/config/cloud/local-dev.properties")
+).forEach{
+    val symlinkTask = tasks.register<Exec>("symlink${it.key}") {
+        val path = it.value.relativeTo(localConfig)
+        if (Os.isFamily(Os.FAMILY_UNIX)) {
+            commandLine("sh", "-c", "ln -sfn ${path} ${it.key}")
+        } else {
+            // https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/
+            val windowsPath = path.toString().replace("[/]".toRegex(), "\\")
+            commandLine("cmd", "/c", """mklink /d "${it.key}" "${windowsPath}" """)
+        }
+        workingDir(localConfig)
+        dependsOn("generateLocalProperties")
+    }
+    symlinkConfigTask.configure {
+        dependsOn(symlinkTask)
+    }
+}
+
+tasks.register<WriteProperties>("generateLocalDeveloperProperties") {
+    dependsOn(symlinkConfigTask)
+    comment = "my.properties - add your own local development configuration parameters here"
+    outputFile = project.file("hybris/config/local-config/99-local.properties")
+    onlyIf {
+        !project.file("hybris/config/local-config/99-local.properties").exists()
+    }
 }
 
 // https://help.sap.com/viewer/b2f400d4c0414461a4bb7e115dccd779/LATEST/en-US/784f9480cf064d3b81af9cad5739fecc.html
@@ -100,5 +137,5 @@ tasks.named("installManifestAddons") {
 tasks.register("setupLocalDevelopment") {
     group = "SAP Commerce"
     description = "Setup local development"
-    dependsOn("bootstrapPlatform", "generateLocalProperties", "installManifestAddons", "enableModeltMock")
+    dependsOn("bootstrapPlatform", "generateLocalDeveloperProperties", "installManifestAddons", "enableModeltMock")
 }


### PR DESCRIPTION
### Improvements are:

1. Make use of authorization header with basic auth, instead of passing username / password to the download task: For some reasons the download was blocked due to an "unauthorized" response. I tried it on bitbucket servers, as well as on github, both refused to pass the configuration forward to SAP. With the authorization header it works fine with both major CI platforms. The Authorization header is calculated based upon the two variables, therefore, this change is backwards compatible and does not require any change in configuration.
2. Fixed a typo within the download area of the extension packs: The commerce version was referenced, therefore, the download was not found and the build failed.
3. Add support for local properties within the build script: The build script now supports to generate the symlinks for the local developers and it is easy to extend, by adding more files to the map configuration object.
4. The local.properties file pointed to ${HYBRIS_CONF_DIR} which could not been resolved on Windows: On some Windows systems the path replacement did not work, because the $HYBRIS_CONF_DIR was not available whilst loading the file. Now the build script sets the absolute path within the local.properties which works very robust on all systems.