### PR TITLE
fixes #27 by removing the /d flag from the mklink command

### DIFF
--- a/core-customize/build.gradle.kts
+++ b/core-customize/build.gradle.kts
@@ -104,7 +104,7 @@ mapOf(
         } else {
             // https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/
             val windowsPath = path.toString().replace("[/]".toRegex(), "\\")
-            commandLine("cmd", "/c", """mklink /d "${it.key}" "${windowsPath}" """)
+            commandLine("cmd", "/c", """mklink "${it.key}" "${windowsPath}" """)
         }
         workingDir(localConfig)
         dependsOn("generateLocalProperties")


### PR DESCRIPTION
The build on windows fails due to directory symlinks being created for the config/local-config/*-local.properties files instead of file symlinks.  I simply just had to remove the /d flag for the build to complete.  Here are the docs from Microsoft on the mklink command - https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/mklink

